### PR TITLE
Remove spurious debug_assert!

### DIFF
--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -100,10 +100,6 @@ where
                     }
                     Ok(Async::Ready(None)) | Ok(Async::NotReady) | Err(_) => break,
                 }
-                debug_assert!(
-                    n_polls.inc() < MAX_SYNC_POLLS,
-                    "Use Self::Context::notify() instead of direct use of address"
-                );
             }
 
             if not_ready {


### PR DESCRIPTION
If you are driving a future which depends on operations that are
completing too fast (e.g. using local sockets to a Redis server) this
assert can be incorrectly triggered.