### PR TITLE
Remove overactive debug_assert!

### DIFF
--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -88,10 +88,6 @@ where
                     }
                     Ok(Async::Ready(None)) | Ok(Async::NotReady) | Err(_) => break,
                 }
-                debug_assert!(
-                    n_polls.inc() < MAX_SYNC_POLLS,
-                    "Use Self::Context::notify() instead of direct use of address"
-                );
             }
 
             if not_ready {


### PR DESCRIPTION
This assert was triggered is streaming data from a source that responded
too quickly (e.g. a Redis instance on the same host).